### PR TITLE
realpath

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ function enoki (opts) {
   assert.equal(typeof opts.directory, 'string', 'opts.directory should be type string')
 
   this.path = {
-    content: path.join(opts.directory, opts.pathContent || 'content'),
-    site: path.join(opts.directory, opts.pathSite || 'site')
+    content: fs.realpathSync(path.join(opts.directory, opts.pathContent || 'content')),
+    site: fs.realpathSync(path.join(opts.directory, opts.pathSite || 'site'))
   }
 
   try {


### PR DESCRIPTION
Adds [`realpathSync`](https://nodejs.org/api/fs.html#fs_fs_realpathsync_path_options) so content and site folders can be resolved even if symlinked 