### PR TITLE
Flat pages/children method

### DIFF
--- a/lib/tools/methods.js
+++ b/lib/tools/methods.js
@@ -146,7 +146,7 @@ function page (state, value) {
 
 function pages (state, value) {
   try {
-    var regex = RegExp('^' + value.url + '\/[^\/]+\/?$')
+    var regex = new RegExp('^' + value.url + '\/[^\/]+\/?$')
     return objectKeys(state.content)
       .filter(key => regex.test(key.trim()))
       .reduce(readPage, { })

--- a/lib/tools/methods.js
+++ b/lib/tools/methods.js
@@ -146,7 +146,8 @@ function page (state, value) {
 
 function pages (state, value) {
   try {
-    var regex = new RegExp('^' + value.url + '\/[^\/]+\/?$')
+    var base = !!value.url.replace(/^\//, '') ? value.url : ''
+    var regex = new RegExp('^' + base + '\/[^\/]+\/?$')
     return objectKeys(state.content)
       .filter(key => regex.test(key.trim()))
       .reduce(readPage, { })

--- a/lib/tools/methods.js
+++ b/lib/tools/methods.js
@@ -146,14 +146,16 @@ function page (state, value) {
 
 function pages (state, value) {
   try {
-    return objectKeys(value.pages).reduce(readPage, { })
+    var regex = RegExp('^' + value.url + '\/[^\/]+\/?$')
+    return objectKeys(state.content)
+      .filter(key => regex.test(key.trim()))
+      .reduce(readPage, { })
   } catch (err) {
     return { }
   }
 
   function readPage (result, key) {
-    var url = value.pages[key].url
-    var page = state.content[url]
+    var page = state.content[key]
     if (page) result[key] = page
     return result
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Jon-Kyle <contact@jon-kyle.com> (http://jon-kyle.com)",
   "dependencies": {
     "hypha": "^0.4.5",
-    "object-key": "^0.2.0",
+    "object-keys": "^1.0.11",
     "object-values": "^1.0.0",
     "parse-dat-url": "^3.0.1",
     "xhr": "^2.4.1",


### PR DESCRIPTION
This implements the enoki tools `children()` method to match top-level keys as described in https://github.com/enokidotsite/enoki/issues/15#issuecomment-381749978

Matching is done using a regular expression so we can match *direct* children:

```js
new RegExp('^\/parent\/[^\/]+\/?$')
```

```bash
/parent # will not match
/parent/child # will match
/parent/child/grandchild # will not match
```

Additionally, this implementation makes an assumption that the `url` field within a page entry in state is `===` to the key of that page in `state.content`. 