### PR TITLE
Added state.site.preloaded for server-side rendering

### DIFF
--- a/lib/adapters/choo.js
+++ b/lib/adapters/choo.js
@@ -12,6 +12,9 @@ function plugin (parent, options) {
     // content state
     state.site = state.site || { loaded: false, p2p: false }
     state.content = state.content || { }
+    
+    // check if the content was preloaded
+    state.site.loaded = state.site.preloaded === true
 
     // nanopage
     state.page = new Page(state)
@@ -23,7 +26,7 @@ function plugin (parent, options) {
     // listeners
     emitter.on(state.events.CONTENT_LOAD, contentLoad)
     // only load the content if it wasn't rehydrated by the server
-    if (!state.site.preloaded) {
+    if (!state.site.loaded) {
       emitter.on(state.events.DOMCONTENTLOADED, contentLoad)
     }
 

--- a/lib/adapters/choo.js
+++ b/lib/adapters/choo.js
@@ -21,8 +21,11 @@ function plugin (parent, options) {
     state.events.CONTENT_LOAD = 'content:load'
 
     // listeners
-    emitter.on(state.events.DOMCONTENTLOADED, contentLoad)
     emitter.on(state.events.CONTENT_LOAD, contentLoad)
+    // only load the content if it wasn't rehydrated by the server
+    if (!state.site.preloaded) {
+      emitter.on(state.events.DOMCONTENTLOADED, contentLoad)
+    }
 
     /**
      * primary method

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ function view (state, emit) {
     `
   }
 }
-``` 
+```
 
 </details>
 


### PR DESCRIPTION
Currently, if you preset the state using `window.initialState` the most optimal thing you can do is to disable the initial rendering. It would be useful to disable the automatic `content.json` request too, as we already have the content at the server level.

This way whenever you also set `state.site.preloaded` to `true` at rehydration, Enoki won't send the request again for `content.json`.